### PR TITLE
feat(bridge): migrate bungee cctp support to cctp-v2

### DIFF
--- a/packages/bridging/src/README.md
+++ b/packages/bridging/src/README.md
@@ -34,7 +34,7 @@ The BridgingSdk supports two types of operations:
 
 Supported bridge providers:
 
-- **Bungee/Socket**: Multi-bridge aggregation platform with support for multiple underlying bridges including Across, CCTP, and others
+- **Bungee/Socket**: Multi-bridge aggregation platform with support for multiple underlying bridges including Across, CCTP V2, and others
 
 > Since `BridgingSdk` is compatible with [TradingSDK](https://github.com/cowprotocol/cow-sdk/tree/main/packages/trading/README.md), almost everything described for `TradingSDK` applies to `BridgingSdk` as well.
 > The main difference is smart contract wallet support. Currently, `BridgingSdk` only supports EOA wallets; this will likely change soon — stay tuned!
@@ -137,7 +137,7 @@ const adapter = new ViemAdapter({
 // Initialize the bridge provider
 const bungeeProvider = new BungeeBridgeProvider({
   apiOptions: {
-    includeBridges: ['across', 'cctp'], // Optional: specify which bridges to include
+    includeBridges: ['across', 'cctp-v2'], // Optional: specify which bridges to include
   },
 })
 
@@ -288,7 +288,7 @@ const tradingSdk: TradingSdk = new TradingSdk(
 
 const bungeeProvider: BungeeBridgeProvider = new BungeeBridgeProvider({
   apiOptions: {
-    includeBridges: ['across', 'cctp'],
+    includeBridges: ['across', 'cctp-v2'],
   },
 })
 
@@ -411,7 +411,7 @@ const adapter = new ViemAdapter({
 
 const bungeeProvider = new BungeeBridgeProvider({
   apiOptions: {
-    includeBridges: ['across', 'cctp'], // Optional: specify which bridges to include
+    includeBridges: ['across', 'cctp-v2'], // Optional: specify which bridges to include
   },
 })
 
@@ -526,7 +526,7 @@ async function main() {
   // Initialize bridge provider
   const bungeeProvider = new BungeeBridgeProvider({
     apiOptions: {
-      includeBridges: ['across', 'cctp'], // Optional: specify which bridges to include
+      includeBridges: ['across', 'cctp-v2'], // Optional: specify which bridges to include
     },
   })
 

--- a/packages/bridging/src/providers/bungee/BungeeBridgeProvider.ts
+++ b/packages/bridging/src/providers/bungee/BungeeBridgeProvider.ts
@@ -263,14 +263,14 @@ export class BungeeBridgeProvider implements HookBridgeProvider<BungeeQuoteResul
 
   async getCancelBridgingTx(_bridgingId: string): Promise<EvmCall> {
     // Support for cancellation will depend on the actual bridge an order went through.
-    // Across & CCTP doesn't support cancellation.
+    // Across & CCTP V2 don't support cancellation.
     // Therefore, not implementing cancellation
     throw new Error('Not implemented')
   }
 
   async getRefundBridgingTx(_bridgingId: string): Promise<EvmCall> {
     // Support for refund will depend on the actual bridge an order went through.
-    // CCTP doesn't support refund.
+    // CCTP V2 doesn't support refund.
     // Across auto-relays refund txns some time after the order expires. No user action needed.
     // Therefore, not implementing refund
     throw new Error('Not implemented')

--- a/packages/bridging/src/providers/bungee/const/misc.ts
+++ b/packages/bridging/src/providers/bungee/const/misc.ts
@@ -28,9 +28,9 @@ export const BungeeTxDataBytesIndices: BungeeTxDataBytesIndicesType = {
       },
     },
   },
-  cctp: {
+  'cctp-v2': {
     // bridgeERC20To
-    ['0xb7dfe9d0'.toLowerCase()]: {
+    ['0x3ca7f5bc'.toLowerCase()]: {
       inputAmount: {
         bytes_startIndex: 8, // first 8 bytes are the routeId, followed by the function selector
         bytes_length: 32, // first 32 bytes of the params are the amount

--- a/packages/bridging/src/providers/bungee/const/misc.ts
+++ b/packages/bridging/src/providers/bungee/const/misc.ts
@@ -37,6 +37,12 @@ export const BungeeTxDataBytesIndices: BungeeTxDataBytesIndicesType = {
         bytesString_startIndex: 2 + 8 * 2, // first two characters are 0x and 8 bytes = 16 chars for the amount
         bytesString_length: 32 * 2, // 32 bytes = 64 chars for the amount
       },
+      outputAmount: {
+        bytes_startIndex: 200, // feeAmount is the 7th parameter -> 8 + 6*32 = 200
+        bytes_length: 32,
+        bytesString_startIndex: 2 + 200 * 2,
+        bytesString_length: 32 * 2,
+      },
     },
   },
   'gnosis-native-bridge': {

--- a/packages/bridging/src/providers/bungee/consts.ts
+++ b/packages/bridging/src/providers/bungee/consts.ts
@@ -8,7 +8,7 @@ export const BUNGEE_MANUAL_API_URL = `${BUNGEE_BASE_URL}${BUNGEE_MANUAL_API_PATH
 export const BUNGEE_EVENTS_API_URL = 'https://microservices.socket.tech/loki'
 export const ACROSS_API_URL = 'https://app.across.to/api'
 
-export const SUPPORTED_BRIDGES: SupportedBridge[] = ['across', 'cctp', 'gnosis-native-bridge']
+export const SUPPORTED_BRIDGES: SupportedBridge[] = ['across', 'cctp-v2', 'gnosis-native-bridge']
 
 export const errorMessageMap = {
   bungee: 'Bungee Api Error',

--- a/packages/bridging/src/providers/bungee/createBungeeDepositCall.test.ts
+++ b/packages/bridging/src/providers/bungee/createBungeeDepositCall.test.ts
@@ -1,0 +1,193 @@
+import { setGlobalAdapter } from '@cowprotocol/sdk-common'
+import { SupportedChainId } from '@cowprotocol/sdk-config'
+import { OrderKind } from '@cowprotocol/sdk-order-book'
+import { createAdapters } from '../../../tests/setup'
+import { QuoteBridgeRequest } from '../../types'
+import { BUNGEE_APPROVE_AND_BRIDGE_V1_ABI } from './abi'
+import { createBungeeDepositCall } from './createBungeeDepositCall'
+import { BungeeBridge, BungeeQuoteWithBuildTx } from './types'
+import { decodeAmountsBungeeTxData, toBridgeQuoteResult } from './util'
+
+export const CCTP_V2_TX_DATA =
+  '0x000001a63ca7f5bc0000000000000000000000000000000000000000000000000000000005f5e1000000000000000000000000000000000000000000000000000000000000002713000000000000000000000000664b591ab924c6bb2caca533ed702386934a11d6000000000000000000000000833589fcd6edb6e08f4c7c32d4f71b54bda029130000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001e8480000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003e8'
+
+function applyPctDiff(base: bigint, compare: bigint, target: bigint): bigint {
+  return (target * compare) / base
+}
+
+describe('createBungeeDepositCall', () => {
+  const adapters = createAdapters()
+
+  beforeEach(() => {
+    setGlobalAdapter(adapters.ethersV5Adapter)
+  })
+
+  it('encodes cctp-v2 calldata rewrite metadata for feeAmount as the proportional secondary field', async () => {
+    const request: QuoteBridgeRequest = {
+      kind: OrderKind.SELL,
+      amount: 100000000n,
+      owner: '0x664B591AB924c6bb2caCA533Ed702386934A11d6',
+      sellTokenChainId: SupportedChainId.BASE,
+      sellTokenAddress: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+      sellTokenDecimals: 6,
+      buyTokenChainId: SupportedChainId.MAINNET,
+      buyTokenAddress: '0xA0b86991c6218b36c1d19d4a2e9Eb0cE3606eB48',
+      buyTokenDecimals: 6,
+      appCode: 'bungee',
+      account: '0x664B591AB924c6bb2caCA533Ed702386934A11d6',
+      signer: '0x664B591AB924c6bb2caCA533Ed702386934A11d6',
+    }
+
+    const quoteWithBuildTx: BungeeQuoteWithBuildTx = {
+      bungeeQuote: {
+        originChainId: SupportedChainId.BASE,
+        destinationChainId: SupportedChainId.MAINNET,
+        userAddress: '0x664B591AB924c6bb2caCA533Ed702386934A11d6',
+        receiverAddress: '0x664B591AB924c6bb2caCA533Ed702386934A11d6',
+        input: {
+          token: {
+            chainId: SupportedChainId.BASE,
+            address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+            name: 'USD Coin',
+            symbol: 'USDC',
+            decimals: 6,
+            logoURI: '',
+            icon: '',
+          },
+          amount: '100000000',
+          priceInUsd: 1,
+          valueInUsd: 100,
+        },
+        route: {
+          quoteId: 'fd868dfdece0f3b1',
+          quoteExpiry: 0,
+          output: {
+            token: {
+              chainId: SupportedChainId.MAINNET,
+              address: '0xA0b86991c6218b36c1d19d4a2e9Eb0cE3606eB48',
+              name: 'USD Coin',
+              symbol: 'USDC',
+              decimals: 6,
+              logoURI: '',
+              icon: '',
+            },
+            amount: '98000000',
+            priceInUsd: 1,
+            valueInUsd: 98,
+            minAmountOut: '98000000',
+            effectiveReceivedInUsd: 98,
+          },
+          affiliateFee: null,
+          approvalData: {
+            spenderAddress: '0x3a23f943181408eac424116af7b7790c94cb97a5',
+            amount: '100000000',
+            tokenAddress: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+            userAddress: '0x664B591AB924c6bb2caCA533Ed702386934A11d6',
+          },
+          gasFee: {
+            gasToken: {
+              chainId: SupportedChainId.BASE,
+              address: '0x0000000000000000000000000000000000000000',
+              symbol: 'ETH',
+              name: 'Ethereum',
+              decimals: 18,
+              icon: '',
+              logoURI: '',
+              chainAgnosticId: null,
+            },
+            gasLimit: '0',
+            gasPrice: '0',
+            estimatedFee: '0',
+            feeInUsd: 0,
+          },
+          slippage: 0,
+          estimatedTime: 0,
+          routeDetails: {
+            name: 'Circle CCTP V2',
+            logoURI: '',
+            routeFee: {
+              token: {
+                chainId: SupportedChainId.BASE,
+                address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+                name: 'USD Coin',
+                symbol: 'USDC',
+                decimals: 6,
+                logoURI: '',
+                icon: '',
+              },
+              amount: '0',
+              feeInUsd: 0,
+              priceInUsd: 1,
+            },
+            dexDetails: null,
+          },
+          refuel: null,
+        },
+        routeBridge: BungeeBridge.CircleCCTPV2,
+        quoteTimestamp: 0,
+      },
+      buildTx: {
+        approvalData: {
+          spenderAddress: '0x3a23f943181408eac424116af7b7790c94cb97a5',
+          amount: '100000000',
+          tokenAddress: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+          userAddress: '0x664B591AB924c6bb2caCA533Ed702386934A11d6',
+        },
+        txData: {
+          data: CCTP_V2_TX_DATA,
+          to: '0x3a23f943181408eac424116af7b7790c94cb97a5',
+          chainId: SupportedChainId.BASE,
+          value: '0',
+        },
+        userOp: '',
+      },
+    }
+
+    const quote = toBridgeQuoteResult(request, 0, quoteWithBuildTx)
+    const call = await createBungeeDepositCall({ request, quote })
+    const decoded = adapters.ethersV5Adapter.utils.decodeFunctionData(
+      BUNGEE_APPROVE_AND_BRIDGE_V1_ABI,
+      'approveAndBridge',
+      call.data,
+    ) as [string, { toString(): string }, { toString(): string }, string]
+
+    expect(decoded[0]).toBe(request.sellTokenAddress)
+    expect(decoded[1].toString()).toBe('100000000')
+    expect(decoded[2].toString()).toBe('0')
+    expect(decoded[3].startsWith(CCTP_V2_TX_DATA)).toBe(true)
+
+    const modifyCalldataParams = `0x${decoded[3].slice(-192)}`
+    const [inputAmountStartIndex, modifyOutputAmount, outputAmountStartIndex] = adapters.ethersV5Adapter.utils.decodeAbi(
+      ['uint256', 'bool', 'uint256'],
+      modifyCalldataParams,
+    ) as [bigint, boolean, bigint]
+
+    expect(inputAmountStartIndex).toBe(8n)
+    expect(modifyOutputAmount).toBe(true)
+    expect(outputAmountStartIndex).toBe(200n)
+  })
+
+  it('would lower feeAmount proportionally when the actual bridged amount is below the quote', () => {
+    const result = decodeAmountsBungeeTxData(CCTP_V2_TX_DATA, BungeeBridge.CircleCCTPV2)
+
+    const quotedAmount = result.inputAmountBigNumber
+    const quotedFeeAmount = result.outputAmountBigNumber!
+    const actualBridgedAmount = 90000000n
+    const adjustedFeeAmount = applyPctDiff(quotedAmount, actualBridgedAmount, quotedFeeAmount)
+
+    expect(adjustedFeeAmount).toBe(1800000n)
+    expect(adjustedFeeAmount).toBeLessThan(quotedFeeAmount)
+  })
+
+  it('would raise feeAmount proportionally when the actual bridged amount is above the quote', () => {
+    const result = decodeAmountsBungeeTxData(CCTP_V2_TX_DATA, BungeeBridge.CircleCCTPV2)
+
+    const quotedAmount = result.inputAmountBigNumber
+    const quotedFeeAmount = result.outputAmountBigNumber!
+    const actualBridgedAmount = 110000000n
+    const adjustedFeeAmount = applyPctDiff(quotedAmount, actualBridgedAmount, quotedFeeAmount)
+
+    expect(adjustedFeeAmount).toBe(2200000n)
+    expect(adjustedFeeAmount).toBeGreaterThan(quotedFeeAmount)
+  })
+})

--- a/packages/bridging/src/providers/bungee/createBungeeDepositCall.ts
+++ b/packages/bridging/src/providers/bungee/createBungeeDepositCall.ts
@@ -1,6 +1,7 @@
 import { BungeeQuoteResult } from './BungeeBridgeProvider'
 import { QuoteBridgeRequest } from '../../types'
 import { BungeeTxDataBytesIndices } from './const/misc'
+import { InputOutputAmountTxDataBytesIndices } from './types'
 import { BUNGEE_APPROVE_AND_BRIDGE_V1_ABI } from './abi'
 import { BungeeApproveAndBridgeV1Addresses } from './const/contracts'
 import { decodeBungeeBridgeTxData } from './util'
@@ -29,9 +30,15 @@ export async function createBungeeDepositCall(params: {
   }
 
   const inputAmountStartIndex = functionParams.inputAmount.bytes_startIndex
-  const modifyOutputAmount = false
-  const outputAmountStartIndex = 0
+  let modifyOutputAmount = false
+  let outputAmountStartIndex = 0
   const nativeTokenExtraFee = 0n // neither across nor cctp-v2 requires additional native token transfer for now
+
+  // Some bridges encode a second proportional uint256 that must be updated alongside input amount.
+  if ('outputAmount' in functionParams) {
+    modifyOutputAmount = true
+    outputAmountStartIndex = (functionParams as InputOutputAmountTxDataBytesIndices).outputAmount.bytes_startIndex
+  }
 
   // Encode extra data as bytes
   const modifyCalldataParams = adapter.utils.encodeAbi(

--- a/packages/bridging/src/providers/bungee/createBungeeDepositCall.ts
+++ b/packages/bridging/src/providers/bungee/createBungeeDepositCall.ts
@@ -31,7 +31,7 @@ export async function createBungeeDepositCall(params: {
   const inputAmountStartIndex = functionParams.inputAmount.bytes_startIndex
   const modifyOutputAmount = false
   const outputAmountStartIndex = 0
-  const nativeTokenExtraFee = 0n // neither across nor cctp requires additional native token transfer for now
+  const nativeTokenExtraFee = 0n // neither across nor cctp-v2 requires additional native token transfer for now
 
   // Encode extra data as bytes
   const modifyCalldataParams = adapter.utils.encodeAbi(

--- a/packages/bridging/src/providers/bungee/getBridgingStatusFromEvents.ts
+++ b/packages/bridging/src/providers/bungee/getBridgingStatusFromEvents.ts
@@ -51,6 +51,6 @@ export async function getBridgingStatusFromEvents(
     }
   }
 
-  // there is no failed case for across - gets auto-refunded - or cctp - attestation can be relayed by anyone on destination chain
+  // there is no failed case for across - gets auto-refunded - or cctp-v2 - attestation can be relayed by anyone on destination chain
   throw new Error('Unknown status')
 }

--- a/packages/bridging/src/providers/bungee/types.ts
+++ b/packages/bridging/src/providers/bungee/types.ts
@@ -183,9 +183,7 @@ export interface InputOutputAmountTxDataBytesIndices
 
 export type BungeeTxDataBytesIndicesType = {
   [K in BungeeBridge]: {
-    [functionSelector: string]: K extends BungeeBridge.Across
-      ? InputAmountTxDataBytesIndices
-      : InputAmountTxDataBytesIndices
+    [functionSelector: string]: InputAmountTxDataBytesIndices | InputOutputAmountTxDataBytesIndices
   }
 }
 

--- a/packages/bridging/src/providers/bungee/types.ts
+++ b/packages/bridging/src/providers/bungee/types.ts
@@ -1,6 +1,6 @@
 import type { SupportedChainId, TargetChainId } from '@cowprotocol/sdk-config'
 
-export type SupportedBridge = 'across' | 'cctp' | 'gnosis-native-bridge'
+export type SupportedBridge = 'across' | 'cctp-v2' | 'gnosis-native-bridge'
 
 export interface BungeeQuoteAPIRequest {
   userAddress: string
@@ -110,14 +110,14 @@ export interface BungeeQuoteAPIResponse {
 
 export enum BungeeBridge {
   'Across' = 'across',
-  'CircleCCTP' = 'cctp',
+  'CircleCCTPV2' = 'cctp-v2',
   'GnosisNative' = 'gnosis-native-bridge',
 }
 
 // Map display names to enum values
 export const BungeeBridgeNames: Record<string, BungeeBridge> = {
   Across: BungeeBridge.Across,
-  'Circle CCTP': BungeeBridge.CircleCCTP,
+  'Circle CCTP V2': BungeeBridge.CircleCCTPV2,
   'Gnosis Native': BungeeBridge.GnosisNative,
 }
 
@@ -209,7 +209,7 @@ export enum BungeeEventStatus {
 
 export enum BungeeBridgeName {
   ACROSS = 'across',
-  CCTP = 'cctp',
+  CCTP_V2 = 'cctp-v2',
 }
 
 export type BungeeEvent = {

--- a/packages/bridging/src/providers/bungee/types.ts
+++ b/packages/bridging/src/providers/bungee/types.ts
@@ -208,6 +208,7 @@ export enum BungeeEventStatus {
 export enum BungeeBridgeName {
   ACROSS = 'across',
   CCTP_V2 = 'cctp-v2',
+  GNOSIS_NATIVE = 'gnosis-native-bridge',
 }
 
 export type BungeeEvent = {

--- a/packages/bridging/src/providers/bungee/util.test.ts
+++ b/packages/bridging/src/providers/bungee/util.test.ts
@@ -11,6 +11,8 @@ import {
 import { BungeeBridge, BungeeQuoteWithBuildTx } from './types'
 import { OrderKind } from '@cowprotocol/sdk-order-book'
 import { SupportedChainId } from '@cowprotocol/sdk-config'
+import { decodeAmountsBungeeTxData } from './util'
+import { CCTP_V2_TX_DATA } from './createBungeeDepositCall.test'
 
 describe('Bungee Utils', () => {
   describe('toBridgeQuoteResult', () => {
@@ -271,6 +273,17 @@ describe('Bungee Utils', () => {
     it('should get display name from bridge', () => {
       expect(getDisplayNameFromBungeeBridge(BungeeBridge.Across)).toBe('Across')
       expect(getDisplayNameFromBungeeBridge('Invalid' as BungeeBridge)).toBeUndefined()
+    })
+  })
+
+  describe('decodeAmountsBungeeTxData', () => {
+    it('should decode the cctp-v2 input amount and feeAmount from txData', () => {
+      const result = decodeAmountsBungeeTxData(CCTP_V2_TX_DATA, BungeeBridge.CircleCCTPV2)
+
+      expect(result.inputAmountBytes).toBe('0x0000000000000000000000000000000000000000000000000000000005f5e100')
+      expect(result.inputAmountBigNumber).toBe(100000000n)
+      expect(result.outputAmountBytes).toBe('0x00000000000000000000000000000000000000000000000000000000001e8480')
+      expect(result.outputAmountBigNumber).toBe(2000000n)
     })
   })
 

--- a/packages/bridging/src/providers/bungee/util.test.ts
+++ b/packages/bridging/src/providers/bungee/util.test.ts
@@ -249,13 +249,13 @@ describe('Bungee Utils', () => {
     it('should convert object to URLSearchParams correctly', () => {
       const params = {
         userAddress: '0x123',
-        includeBridges: ['across', 'cctp'],
+        includeBridges: ['across', 'cctp-v2'],
         amount: '1000',
       }
 
       const result = objectToSearchParams(params)
       expect(result.get('userAddress')).toBe('0x123')
-      expect(result.get('includeBridges')).toBe('across,cctp')
+      expect(result.get('includeBridges')).toBe('across,cctp-v2')
       expect(result.get('amount')).toBe('1000')
     })
   })
@@ -263,6 +263,8 @@ describe('Bungee Utils', () => {
   describe('BungeeBridge helpers', () => {
     it('should get bridge from display name', () => {
       expect(getBungeeBridgeFromDisplayName('Across')).toBe(BungeeBridge.Across)
+      expect(getBungeeBridgeFromDisplayName('Circle CCTP V2')).toBe(BungeeBridge.CircleCCTPV2)
+      expect(getBungeeBridgeFromDisplayName('Gnosis Native')).toBe(BungeeBridge.GnosisNative)
       expect(getBungeeBridgeFromDisplayName('Invalid')).toBeUndefined()
     })
 

--- a/packages/bridging/src/providers/bungee/util.ts
+++ b/packages/bridging/src/providers/bungee/util.ts
@@ -158,10 +158,10 @@ export function calculateFeeBps(feeAmountBig: bigint, amountBig: bigint): number
  * @example
  * const params = {
  *   userAddress: '0x123',
- *   includeBridges: ['across', 'cctp']
+ *   includeBridges: ['across', 'cctp-v2']
  * }
  * const searchParams = objectToSearchParams(params)
- * Results in: ?userAddress=0x123&includeBridges=across,cctp
+ * Results in: ?userAddress=0x123&includeBridges=across,cctp-v2
  */
 export function objectToSearchParams(params: object): URLSearchParams {
   const searchParams = new URLSearchParams()

--- a/packages/bridging/src/providers/bungee/util.ts
+++ b/packages/bridging/src/providers/bungee/util.ts
@@ -187,7 +187,15 @@ export const getDisplayNameFromBungeeBridge = (bridge: BungeeBridge): string | u
   return Object.entries(BungeeBridge).find(([_, value]) => value === bridge)?.[0]
 }
 
-export const decodeAmountsBungeeTxData = (txData: string, bridge: BungeeBridge) => {
+export const decodeAmountsBungeeTxData = (
+  txData: string,
+  bridge: BungeeBridge,
+): {
+  inputAmountBytes: string
+  inputAmountBigNumber: bigint
+  outputAmountBytes?: string
+  outputAmountBigNumber?: bigint
+} => {
   if (!txData || !txData.startsWith('0x')) {
     throw new Error('Invalid txData format')
   }
@@ -211,6 +219,21 @@ export const decodeAmountsBungeeTxData = (txData: string, bridge: BungeeBridge) 
     functionParams.inputAmount.bytesString_startIndex + functionParams.inputAmount.bytesString_length,
   )}`
   const inputAmountBigNumber = BigInt(inputAmountBytes)
+
+  if ('outputAmount' in functionParams) {
+    const outputAmountBytes = `0x${txData.slice(
+      functionParams.outputAmount.bytesString_startIndex,
+      functionParams.outputAmount.bytesString_startIndex + functionParams.outputAmount.bytesString_length,
+    )}`
+    const outputAmountBigNumber = BigInt(outputAmountBytes)
+
+    return {
+      inputAmountBytes,
+      inputAmountBigNumber,
+      outputAmountBytes,
+      outputAmountBigNumber,
+    }
+  }
 
   return {
     inputAmountBytes,


### PR DESCRIPTION
The `approveAndBridge(...)` call shape is unchanged (same 4 args), and we still append the same 3-word `modifyCalldataParams` trailer. What changed is the values in that trailer for `cctp-v2`: we now send `modifyOutputAmount = true` and `outputAmountStartIndex = 200` (the `feeAmount` slot), so the wrapper contract recalculates that field proportionally. That wiring is in `misc.ts` and consumed in `createBungeeDepositCall.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Bridging to use CCTP V2 across configs and examples.
* **Enhancements**
  * Added decoding of input and optional output amounts for CCTP V2 transactions.
  * Transaction building now supports optional output-amount handling used for fee adjustments.
* **Tests**
  * Expanded tests covering CCTP V2 encoding/decoding and proportional fee-adjustment scenarios.
* **Documentation**
  * Updated README and in-code examples to reference CCTP V2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->